### PR TITLE
Add Desugar Support for `ThreadLocal#withInitial`

### DIFF
--- a/jdk11/src/java.base/share/classes/java/lang/ThreadLocal.java
+++ b/jdk11/src/java.base/share/classes/java/lang/ThreadLocal.java
@@ -24,6 +24,7 @@
  */
 
 package java.lang;
+import com.google.devtools.build.android.annotations.DesugarSupportedApi;
 import jdk.internal.misc.TerminatingThreadLocal;
 
 import java.lang.ref.*;
@@ -139,6 +140,7 @@ public class ThreadLocal<T> {
      * @throws NullPointerException if the specified supplier is null
      * @since 1.8
      */
+    @DesugarSupportedApi
     public static <S> ThreadLocal<S> withInitial(Supplier<? extends S> supplier) {
         return new SuppliedThreadLocal<>(supplier);
     }

--- a/src/share/classes/java/lang/DesugarThreadLocal.java
+++ b/src/share/classes/java/lang/DesugarThreadLocal.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * This class provides thread-local variables.  These variables differ from
+ * their normal counterparts in that each thread that accesses one (via its
+ * {@code get} or {@code set} method) has its own, independently initialized
+ * copy of the variable.  {@code ThreadLocal} instances are typically private
+ * static fields in classes that wish to associate state with a thread (e.g.,
+ * a user ID or Transaction ID).
+ *
+ * <p>For example, the class below generates unique identifiers local to each
+ * thread.
+ * A thread's id is assigned the first time it invokes {@code ThreadId.get()}
+ * and remains unchanged on subsequent calls.
+ * <pre>
+ * import java.util.concurrent.atomic.AtomicInteger;
+ *
+ * public class ThreadId {
+ *     // Atomic integer containing the next thread ID to be assigned
+ *     private static final AtomicInteger nextId = new AtomicInteger(0);
+ *
+ *     // Thread local variable containing each thread's ID
+ *     private static final ThreadLocal&lt;Integer&gt; threadId =
+ *         new ThreadLocal&lt;Integer&gt;() {
+ *             &#64;Override protected Integer initialValue() {
+ *                 return nextId.getAndIncrement();
+ *         }
+ *     };
+ *
+ *     // Returns the current thread's unique ID, assigning it if necessary
+ *     public static int get() {
+ *         return threadId.get();
+ *     }
+ * }
+ * </pre>
+ * <p>Each thread holds an implicit reference to its copy of a thread-local
+ * variable as long as the thread is alive and the {@code ThreadLocal}
+ * instance is accessible; after a thread goes away, all of its copies of
+ * thread-local instances are subject to garbage collection (unless other
+ * references to these copies exist).
+ *
+ * @author  Josh Bloch and Doug Lea
+ * @since   1.2
+ */
+// for desugar: Copy of java.lang.ThreadLocal with members introduced since 1.8
+public class DesugarThreadLocal {
+
+    // for desugar: static methods only
+    private DesugarThreadLocal() {
+    }
+
+    /**
+     * Creates a thread local variable. The initial value of the variable is
+     * determined by invoking the {@code get} method on the {@code Supplier}.
+     *
+     * @param <S> the type of the thread local's value
+     * @param supplier the supplier to be used to determine the initial value
+     * @return a new thread local variable
+     * @throws NullPointerException if the specified supplier is null
+     * @since 1.8
+     */
+    public static <S> ThreadLocal<S> withInitial(Supplier<? extends S> supplier) {
+        return new SuppliedThreadLocal<>(supplier);
+    }
+
+    /**
+     * An extension of ThreadLocal that obtains its initial value from
+     * the specified {@code Supplier}.
+     */
+    static final class SuppliedThreadLocal<T> extends ThreadLocal<T> {
+
+        private final Supplier<? extends T> supplier;
+
+        SuppliedThreadLocal(Supplier<? extends T> supplier) {
+            this.supplier = Objects.requireNonNull(supplier);
+        }
+
+        @Override
+        protected T initialValue() {
+            return supplier.get();
+        }
+    }
+}


### PR DESCRIPTION
I used this with the following changes to `desugar_jdk_libs.json` in the r8 repo.

```diff
diff --git a/src/library_desugar/desugar_jdk_libs.json b/src/library_desugar/desugar_jdk_libs.json
index 1b2e6bf1ef..9c64705608 100644
--- a/src/library_desugar/desugar_jdk_libs.json
+++ b/src/library_desugar/desugar_jdk_libs.json
@@ -75,9 +75,11 @@
       "rewrite_prefix": {
         "j$.time.": "java.time.",
         "java.time.": "j$.time.",
-        "java.util.Desugar": "j$.util.Desugar"
+        "java.util.Desugar": "j$.util.Desugar",
+        "java.lang.Desugar": "j$.lang.Desugar"
       },
       "retarget_lib_member": {
+        "java.lang.ThreadLocal#withInitial": "java.lang.DesugarThreadLocal",
         "java.util.Date#toInstant": "java.util.DesugarDate",
         "java.util.GregorianCalendar#toZonedDateTime": "java.util.DesugarGregorianCalendar",
         "java.util.TimeZone#toZoneId": "java.util.DesugarTimeZone"
@@ -154,9 +156,11 @@
       "api_level_below_or_equal": 25,
       "rewrite_prefix": {
         "java.time.": "j$.time.",
-        "java.util.Desugar": "j$.util.Desugar"
+        "java.util.Desugar": "j$.util.Desugar",
+        "java.lang.Desugar": "j$.lang.Desugar"
       },
       "retarget_lib_member": {
+        "java.lang.ThreadLocal#withInitial": "java.lang.DesugarThreadLocal",
         "java.util.Calendar#toInstant": "java.util.DesugarCalendar",
         "java.util.Date#from": "java.util.DesugarDate",
         "java.util.Date#toInstant": "java.util.DesugarDate",
```

See https://issuetracker.google.com/issues/160484830