### PR TITLE
Replace use of `genrule.exec_tools` with `tools`.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,7 +18,7 @@ genrule(
           " --version_file $(location VERSION_JDK11_LEGACY.txt)" +
           " --dependencies_file $(location DEPENDENCIES_JDK11_LEGACY.txt)" +
           " --out $@",
-    exec_tools = [":build_maven_artifact"],
+    tools = [":build_maven_artifact"],
 )
 
 genrule(
@@ -35,7 +35,7 @@ genrule(
           " --version_file $(location VERSION_JDK11_MINIMAL.txt)" +
           " --dependencies_file $(location DEPENDENCIES_JDK11_MINIMAL.txt)" +
           " --out $@",
-    exec_tools = [":build_maven_artifact"],
+    tools = [":build_maven_artifact"],
 )
 
 genrule(
@@ -52,7 +52,7 @@ genrule(
           " --version_file $(location VERSION_JDK11.txt)" +
           " --dependencies_file $(location DEPENDENCIES_JDK11.txt)" +
           " --out $@",
-    exec_tools = [":build_maven_artifact"],
+    tools = [":build_maven_artifact"],
 )
 
 genrule(
@@ -69,7 +69,7 @@ genrule(
           " --version_file $(location VERSION_JDK11_NIO.txt)" +
           " --dependencies_file $(location DEPENDENCIES_JDK11_NIO.txt)" +
           " --out $@",
-    exec_tools = [":build_maven_artifact"],
+    tools = [":build_maven_artifact"],
 )
 
 py_binary(

--- a/jdk11/src/BUILD
+++ b/jdk11/src/BUILD
@@ -13,9 +13,9 @@ java_library(
     ],
     visibility = ["//:__pkg__"],
     deps = [
+        "//:android_jar",
         "//jdk11/desugarconfig",
         "//jdk11/src/addon",
-        "//:android_jar",
         "//jdk11/src/stubs",
     ],
 )
@@ -29,7 +29,7 @@ genrule(
     cmd = """
       $(location //:tools/jdk_type_selector) $(location :java_base_all) $@ "--config=d8_desugar"
     """,
-    exec_tools = ["//:tools/jdk_type_selector"],
+    tools = ["//:tools/jdk_type_selector"],
     visibility = ["//:__pkg__"],
 )
 
@@ -62,6 +62,6 @@ genrule(
     cmd = """
       $(location //:tools/jdk_type_selector) $(location :java_base_all) $@ "--config=android_fix_libs"
     """,
-    exec_tools = ["//:tools/jdk_type_selector"],
+    tools = ["//:tools/jdk_type_selector"],
     visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
Part of https://github.com/bazelbuild/bazel/issues/19132