### PR TITLE
Reduce output from unzip

### DIFF
--- a/jdk11/src/BUILD
+++ b/jdk11/src/BUILD
@@ -43,9 +43,9 @@ genrule(
     outs = ["d8_java_base_selected_with_addon.jar"],
     cmd = """
         TMPDIR="$$(mktemp -d)"
-        unzip -o $(location d8_java_base_selected) -d "$$TMPDIR"/
-        unzip -o $(location //jdk11/src/libcore:libcore_addon) -d "$$TMPDIR"/
-        unzip -o $(location //jdk11/src/addon) -d "$$TMPDIR"/
+        unzip -oq $(location d8_java_base_selected) -d "$$TMPDIR"/
+        unzip -oq $(location //jdk11/src/libcore:libcore_addon) -d "$$TMPDIR"/
+        unzip -oq $(location //jdk11/src/addon) -d "$$TMPDIR"/
         MYHOME=$$PWD
         cd $$TMPDIR
         zip -DXr1 "$$MYHOME/$@" .


### PR DESCRIPTION
Hopefully reduce the [log](https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/17420#018a8497-1c9c-4973-bee3-fe780b8170f9) size from Bazel build:
```
(14:17:30) INFO: From Executing genrule @_main~bazel_android_deps~desugar_jdk_libs//jdk11/src:d8_java_base_selected_with_addon:
Archive:  bazel-out/x64_windows-fastbuild/bin/external/_main~bazel_android_deps~desugar_jdk_libs/jdk11/src/d8_java_base_selected.jar
 extracting: /tmp/tmp.JJPIKw5hSa/java/io/BufferedInputStream.class
 extracting: /tmp/tmp.JJPIKw5hSa/java/io/DesugarBufferedReader.class
 extracting: /tmp/tmp.JJPIKw5hSa/java/io/DesugarBufferedReaderLinesIterator.class
 extracting: /tmp/tmp.JJPIKw5hSa/java/io/DesugarInputStream.class
 extracting: /tmp/tmp.JJPIKw5hSa/java/io/DesugarFile.class
 extracting: /tmp/tmp.JJPIKw5hSa/java/io/UncheckedIOException.class
 extracting: /tmp/tmp.JJPIKw5hSa/java/lang/AbstractStringBuilder.class
 extracting: /tmp/tmp.JJPIKw5hSa/java/lang/CharSequence$1CharIterator.class
 extracting: /tmp/tmp.JJPIKw5hSa/java/lang/CharSequence$1CodePointIterator.class
```